### PR TITLE
Fix bug causing a panic when ``LinkNode == nil``

### DIFF
--- a/scraper.go
+++ b/scraper.go
@@ -92,6 +92,10 @@ func (s *Scraper) parse(n *html.Node) {
 }
 
 func (s *Scraper) attr(n *html.Node, key string) string {
+	if n == nil {
+		return ""
+	}
+	
 	for _, a := range n.Attr {
 		if a.Key == key {
 			return a.Val


### PR DESCRIPTION
Fix bug causing a panic when `LinkNode == nil` (when there is no meta specifying favicon on the website):

```
2015/03/08 13:26:46 http: panic serving 172.17.42.1:39196: runtime error: invalid memory address or nil pointer dereference
goroutine 186 [running]:
net/http.func·011()
  /home/thomas/go/src/net/http/server.go:1130 +0xbb
github.com/subosito/shorticon.(*Scraper).attr(0xc2082b0140, 0x0, 0x772a70, 0x4, 0x0, 0x0)
  /home/thomas/gopath/src/github.com/subosito/shorticon/scraper.go:95 +0x183
github.com/subosito/shorticon.(*Scraper).Favicon(0xc2082b0140, 0x18, 0x0, 0x0)
  /home/thomas/gopath/src/github.com/subosito/shorticon/scraper.go:57 +0x34c
[...]
```
